### PR TITLE
Complete schema-first conformance coverage

### DIFF
--- a/BbQ.ChatWidgets.Blazor/Services/WidgetStreamReconciler.cs
+++ b/BbQ.ChatWidgets.Blazor/Services/WidgetStreamReconciler.cs
@@ -1,0 +1,63 @@
+using System.Text.Json.Nodes;
+using BbQ.ChatWidgets.Models;
+
+namespace BbQ.ChatWidgets.Blazor.Services;
+
+/// <summary>Revision-aware Schema First state adapter for Blazor components.</summary>
+public sealed class WidgetStreamReconciler
+{
+    private readonly Dictionary<Guid, WidgetRevisionedState> _widgets = [];
+    private readonly HashSet<string> _eventIds = [];
+    /// <summary>Gets current widget state keyed by server-owned instance ID.</summary>
+    public IReadOnlyDictionary<Guid, WidgetRevisionedState> Widgets => _widgets;
+
+    /// <summary>Applies one envelope and invokes lifecycle callbacks only for its widget.</summary>
+    public WidgetTransitionOutcome Apply(WidgetStreamEvent value, IBlazorWidgetLifecycle lifecycle)
+    {
+        if (!_eventIds.Add(value.EventId) || value.Kind is WidgetStreamEventKind.Heartbeat) return WidgetTransitionOutcome.NoChange;
+        if (value.Kind is WidgetStreamEventKind.ResyncRequired || value.InstanceId is null || value.Revision is null) return WidgetTransitionOutcome.ResyncRequired;
+        var id = value.InstanceId.Value;
+        _widgets.TryGetValue(id, out var current);
+        if (current is not null && value.Revision <= current.Revision) return WidgetTransitionOutcome.NoChange;
+        if (value.Kind is WidgetStreamEventKind.Snapshot or WidgetStreamEventKind.Upsert)
+        {
+            var next = new WidgetRevisionedState(id, value.Revision.Value, value.Payload);
+            _widgets[id] = next;
+            if (current is null) lifecycle.Mount(id, next); else lifecycle.Update(id, current, next);
+            return WidgetTransitionOutcome.Applied;
+        }
+        if (current is null || value.BaseRevision != current.Revision) return WidgetTransitionOutcome.ResyncRequired;
+        if (value.Kind is WidgetStreamEventKind.Remove)
+        {
+            _widgets.Remove(id); lifecycle.Unmount(id, current); return WidgetTransitionOutcome.Applied;
+        }
+        if (value.Kind is not WidgetStreamEventKind.Patch) return WidgetTransitionOutcome.NoChange;
+        try
+        {
+            var node = JsonNode.Parse(current.State.GetRawText())!;
+            foreach (var operation in value.Payload.EnumerateArray())
+            {
+                var path = operation.GetProperty("path").GetString()!;
+                if (!path.StartsWith('/') || path[1..].Contains('/')) return WidgetTransitionOutcome.ResyncRequired;
+                var property = path[1..].Replace("~1", "/", StringComparison.Ordinal).Replace("~0", "~", StringComparison.Ordinal);
+                var obj = node.AsObject();
+                if (operation.GetProperty("op").GetString() == "remove") obj.Remove(property);
+                else obj[property] = JsonNode.Parse(operation.GetProperty("value").GetRawText());
+            }
+            var next = new WidgetRevisionedState(id, value.Revision.Value, System.Text.Json.JsonSerializer.SerializeToElement(node));
+            _widgets[id] = next; lifecycle.Update(id, current, next); return WidgetTransitionOutcome.Applied;
+        }
+        catch { return WidgetTransitionOutcome.ResyncRequired; }
+    }
+}
+
+/// <summary>Receives keyed Blazor component lifecycle transitions.</summary>
+public interface IBlazorWidgetLifecycle
+{
+    /// <summary>Mounts a new component.</summary>
+    void Mount(Guid instanceId, WidgetRevisionedState state);
+    /// <summary>Updates an existing component.</summary>
+    void Update(Guid instanceId, WidgetRevisionedState previous, WidgetRevisionedState next);
+    /// <summary>Unmounts a removed component.</summary>
+    void Unmount(Guid instanceId, WidgetRevisionedState state);
+}

--- a/BbQ.ChatWidgets.Tests/BbQ.ChatWidgets.Tests.csproj
+++ b/BbQ.ChatWidgets.Tests/BbQ.ChatWidgets.Tests.csproj
@@ -22,6 +22,15 @@
 
   <ItemGroup>
     <ProjectReference Include="..\BbQ.ChatWidgets\BbQ.ChatWidgets.csproj" />
+    <ProjectReference Include="..\BbQ.ChatWidgets.Blazor\BbQ.ChatWidgets.Blazor.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\test-fixtures\schema-first-lifecycle.json" Link="test-fixtures\schema-first-lifecycle.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>

--- a/BbQ.ChatWidgets.Tests/Integration/SchemaFirstFixtureConformanceTests.cs
+++ b/BbQ.ChatWidgets.Tests/Integration/SchemaFirstFixtureConformanceTests.cs
@@ -1,0 +1,39 @@
+using System.Text.Json;
+using BbQ.ChatWidgets.Blazor.Services;
+using BbQ.ChatWidgets.Models;
+using Xunit;
+
+namespace BbQ.ChatWidgets.Tests.Integration;
+
+public sealed class SchemaFirstFixtureConformanceTests
+{
+    [Fact]
+    public void SharedFixture_DeserializesFormAndDrivesBlazorLifecycleGapRecoveryAndRemoval()
+    {
+        using var fixture = JsonDocument.Parse(File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "test-fixtures", "schema-first-lifecycle.json")));
+        var formEvent = fixture.RootElement.GetProperty("form").Deserialize<WidgetStreamEvent>(Serialization.Default)!;
+        var form = formEvent.Payload.Deserialize<ChatWidget>(Serialization.Default);
+        Assert.IsType<FormWidget>(form);
+
+        var reconciler = new WidgetStreamReconciler();
+        var lifecycle = new RecordingLifecycle();
+        Assert.Equal(WidgetTransitionOutcome.Applied, reconciler.Apply(formEvent, lifecycle));
+        var events = fixture.RootElement.GetProperty("events").EnumerateArray().Select(x => x.Deserialize<WidgetStreamEvent>(Serialization.Default)!).ToArray();
+        Assert.Equal(WidgetTransitionOutcome.Applied, reconciler.Apply(events[0], lifecycle));
+        Assert.Equal(WidgetTransitionOutcome.Applied, reconciler.Apply(events[1], lifecycle));
+        Assert.Equal(WidgetTransitionOutcome.ResyncRequired, reconciler.Apply(events[2], lifecycle));
+        Assert.Equal(WidgetTransitionOutcome.Applied, reconciler.Apply(events[3], lifecycle));
+        Assert.Equal(75, reconciler.Widgets[events[3].InstanceId!.Value].State.GetProperty("value").GetInt32());
+        Assert.Equal(WidgetTransitionOutcome.Applied, reconciler.Apply(events[4], lifecycle));
+        Assert.DoesNotContain(events[4].InstanceId!.Value, reconciler.Widgets.Keys);
+        Assert.Equal(["mount", "mount", "update", "update", "unmount"], lifecycle.Calls);
+    }
+
+    private sealed class RecordingLifecycle : IBlazorWidgetLifecycle
+    {
+        public List<string> Calls { get; } = [];
+        public void Mount(Guid instanceId, WidgetRevisionedState state) => Calls.Add("mount");
+        public void Update(Guid instanceId, WidgetRevisionedState previous, WidgetRevisionedState next) => Calls.Add("update");
+        public void Unmount(Guid instanceId, WidgetRevisionedState state) => Calls.Add("unmount");
+    }
+}

--- a/BbQ.ChatWidgets.Tests/Services/WidgetSseServiceTests.cs
+++ b/BbQ.ChatWidgets.Tests/Services/WidgetSseServiceTests.cs
@@ -1,0 +1,163 @@
+using System.Text;
+using System.Text.Json;
+using BbQ.ChatWidgets.Models;
+using BbQ.ChatWidgets.Options;
+using BbQ.ChatWidgets.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace BbQ.ChatWidgets.Tests.Services;
+
+public sealed class WidgetSseServiceTests
+{
+    [Fact]
+    public async Task SubscribeAsync_ReplaysOnlyEventsAfterLastEventId()
+    {
+        var service = Create(replay: 8);
+        await service.PublishEventAsync(Event("one", 1));
+        await service.PublishEventAsync(Event("two", 2));
+        await service.PublishEventAsync(Event("three", 3));
+        var (context, body) = Context("one");
+
+        await SubscribeBriefly(service, context);
+        var text = Encoding.UTF8.GetString(body.ToArray());
+
+        Assert.DoesNotContain("id: one", text);
+        Assert.Contains("id: two", text);
+        Assert.Contains("id: three", text);
+    }
+
+    [Fact]
+    public async Task SubscribeAsync_RequestsResyncWhenReplayIdWasNotRetained()
+    {
+        var service = Create(replay: 2);
+        await service.PublishEventAsync(Event("one", 1));
+        await service.PublishEventAsync(Event("two", 2));
+        await service.PublishEventAsync(Event("three", 3));
+        var (context, body) = Context("one");
+
+        await SubscribeBriefly(service, context);
+        var text = Encoding.UTF8.GetString(body.ToArray());
+
+        Assert.Contains("event: stream.resync-required", text);
+        Assert.Contains("replay-gap", text);
+    }
+
+    [Fact]
+    public async Task SubscribeAsync_CancellationCompletesAndRemovesSubscriber()
+    {
+        var service = Create(heartbeat: TimeSpan.FromHours(1));
+        var (context, _) = Context();
+        using var cancellation = new CancellationTokenSource();
+        var subscription = service.SubscribeAsync("stream", context, cancellation.Token);
+        cancellation.Cancel();
+
+        await subscription.WaitAsync(TimeSpan.FromSeconds(2));
+        await service.PublishEventAsync(Event("after-cancel", 1));
+    }
+
+    [Fact]
+    public async Task IdleSubscription_EmitsHeartbeatWithoutWidgetRevision()
+    {
+        var service = Create(heartbeat: TimeSpan.FromMilliseconds(10));
+        var (context, body) = Context();
+
+        await SubscribeBriefly(service, context);
+        var text = Encoding.UTF8.GetString(body.ToArray());
+
+        Assert.Contains("event: stream.heartbeat", text);
+        Assert.Contains("\"protocolVersion\":\"1.0\"", text);
+        Assert.DoesNotContain("\"revision\"", text);
+    }
+
+    [Fact]
+    public async Task PublishEventAsync_IsSafeForConcurrentPublishersAndReplay()
+    {
+        const int count = 32;
+        var service = Create(buffer: count, replay: count);
+        var (context, body) = Context();
+        using var cancellation = new CancellationTokenSource();
+        var subscription = service.SubscribeAsync("stream", context, cancellation.Token);
+        await Task.Delay(25);
+        await Task.WhenAll(Enumerable.Range(1, count).Select(i => service.PublishEventAsync(Event($"event-{i}", i))));
+        await Task.Delay(75);
+        cancellation.Cancel();
+        await subscription;
+        var text = Encoding.UTF8.GetString(body.ToArray());
+
+        Assert.Equal(count, text.Split("event: widget.snapshot", StringSplitOptions.None).Length - 1);
+    }
+
+    [Fact]
+    public async Task SlowSubscriberOverflow_EmitsResyncWithoutUnboundedBuffering()
+    {
+        var service = Create(buffer: 1, replay: 16, heartbeat: TimeSpan.FromHours(1));
+        var gate = new BlockingWriteStream();
+        var context = new DefaultHttpContext();
+        context.Response.Body = gate;
+        using var cancellation = new CancellationTokenSource();
+        var subscription = service.SubscribeAsync("stream", context, cancellation.Token);
+        await Task.Delay(25);
+
+        for (var i = 1; i <= 8; i++) await service.PublishEventAsync(Event($"event-{i}", i));
+        gate.Release();
+        await gate.WaitForTextAsync("subscriber-buffer-overflow", TimeSpan.FromSeconds(2));
+        cancellation.Cancel();
+        await subscription;
+
+        Assert.Contains("event: stream.resync-required", gate.Text);
+    }
+
+    private static WidgetSseService Create(int buffer = 8, int replay = 8, TimeSpan? heartbeat = null) =>
+        new(Microsoft.Extensions.Options.Options.Create(new WidgetSseOptions
+        {
+            SubscriberBufferCapacity = buffer,
+            ReplayCapacity = replay,
+            HeartbeatInterval = heartbeat ?? TimeSpan.FromMilliseconds(20)
+        }));
+
+    private static WidgetStreamEvent Event(string id, long revision) => new(
+        WidgetStreamEvent.CurrentProtocolVersion,
+        id,
+        "stream",
+        Guid.Parse("11111111-1111-1111-1111-111111111111"),
+        null,
+        revision,
+        WidgetStreamEventKind.Snapshot,
+        DateTimeOffset.UtcNow,
+        JsonSerializer.SerializeToElement(new { type = "card", title = id }));
+
+    private static (DefaultHttpContext Context, MemoryStream Body) Context(string? lastEventId = null)
+    {
+        var context = new DefaultHttpContext();
+        var body = new MemoryStream();
+        context.Response.Body = body;
+        if (lastEventId is not null) context.Request.Headers["Last-Event-ID"] = lastEventId;
+        return (context, body);
+    }
+
+    private static async Task SubscribeBriefly(WidgetSseService service, DefaultHttpContext context)
+    {
+        using var cancellation = new CancellationTokenSource(TimeSpan.FromMilliseconds(75));
+        await service.SubscribeAsync("stream", context, cancellation.Token);
+    }
+
+    private sealed class BlockingWriteStream : MemoryStream
+    {
+        private readonly TaskCompletionSource _gate = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public string Text => Encoding.UTF8.GetString(ToArray());
+        public void Release() => _gate.TrySetResult();
+        public async Task WaitForTextAsync(string value, TimeSpan timeout)
+        {
+            var deadline = DateTime.UtcNow + timeout;
+            while (!Text.Contains(value, StringComparison.Ordinal) && DateTime.UtcNow < deadline) await Task.Delay(10);
+            Assert.Contains(value, Text);
+        }
+        public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            await _gate.Task.WaitAsync(cancellationToken);
+            await base.WriteAsync(buffer, cancellationToken);
+        }
+    }
+}

--- a/BbQ.ChatWidgets/Services/WidgetSseService.cs
+++ b/BbQ.ChatWidgets/Services/WidgetSseService.cs
@@ -53,7 +53,8 @@ public sealed class WidgetSseService : IWidgetSseService
 
         lock (state.Sync)
         {
-            foreach (var frame in ReplayAfter(state, streamId, lastEventId)) subscriber.Channel.Writer.TryWrite(frame);
+            foreach (var frame in ReplayAfter(state, streamId, lastEventId))
+                if (!subscriber.Channel.Writer.TryWrite(frame)) subscriber.Overflowed = true;
             state.Subscribers.Add(subscriber);
         }
 

--- a/js-angular/package-lock.json
+++ b/js-angular/package-lock.json
@@ -13,6 +13,7 @@
         "@angular/cli": "^21.0.5",
         "@angular/compiler-cli": "^21.0.0",
         "@bbq-chat/widgets": "file:../js",
+        "@types/node": "^20.19.0",
         "jsdom": "^27.1.0",
         "ng-packagr": "^21.0.0",
         "typescript": "~5.9.2",
@@ -9019,6 +9020,23 @@
       "peerDependencies": {
         "zod": "^3.25 || ^4"
       }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/js-angular/package.json
+++ b/js-angular/package.json
@@ -50,6 +50,7 @@
     "@angular/cli": "^21.0.5",
     "@angular/compiler-cli": "^21.0.0",
     "@bbq-chat/widgets": "file:../js",
+    "@types/node": "^20.19.0",
     "jsdom": "^27.1.0",
     "ng-packagr": "^21.0.0",
     "typescript": "~5.9.2",

--- a/js-angular/src/public_api.ts
+++ b/js-angular/src/public_api.ts
@@ -102,6 +102,7 @@ export {
 
 // Examples
 export { FormValidationListenerComponent } from './examples/form-validation-listener.component';
+export { AngularSchemaFirstWidgetConsumer } from './schema-first-widget-consumer';
 
 // Version
 export const VERSION = '1.0.11';

--- a/js-angular/src/schema-first-widget-consumer.spec.ts
+++ b/js-angular/src/schema-first-widget-consumer.spec.ts
@@ -1,0 +1,20 @@
+/// <reference types="node" />
+import { readFileSync } from 'node:fs';
+import { describe, expect, it, vi } from 'vitest';
+import type { WidgetManager } from '@bbq-chat/widgets';
+import { AngularSchemaFirstWidgetConsumer } from './schema-first-widget-consumer';
+
+describe('AngularSchemaFirstWidgetConsumer', () => {
+  it('consumes the shared fixture and requests resync for its intentional gap', () => {
+    const fixture = JSON.parse(readFileSync('../test-fixtures/schema-first-lifecycle.json', 'utf8'));
+    const manager = { updateWidget: vi.fn(), unmountWidget: vi.fn() } as unknown as WidgetManager;
+    const resync = vi.fn();
+    const consumer = new AngularSchemaFirstWidgetConsumer(manager, undefined, resync);
+    consumer.consume(fixture.form);
+    fixture.events.forEach((event: never) => consumer.consume(event));
+
+    expect(manager.updateWidget).toHaveBeenCalledTimes(4);
+    expect(manager.unmountWidget).toHaveBeenCalledTimes(1);
+    expect(resync).toHaveBeenCalledWith('revision-gap');
+  });
+});

--- a/js-angular/src/schema-first-widget-consumer.ts
+++ b/js-angular/src/schema-first-widget-consumer.ts
@@ -1,0 +1,14 @@
+import { WidgetManager, WidgetStreamReducer, type WidgetStreamEvent } from '@bbq-chat/widgets';
+
+/** Angular adapter for the shared revision reducer and keyed renderer lifecycle. */
+export class AngularSchemaFirstWidgetConsumer {
+  constructor(private readonly manager: WidgetManager, private readonly reducer = new WidgetStreamReducer(), private readonly requestResync: (reason: string) => void = () => undefined) {}
+  consume(event: WidgetStreamEvent): void {
+    const result = this.reducer.reduce(event);
+    if (result.status === 'resync-required') this.requestResync(result.reason);
+    else if (result.status === 'applied') {
+      if (result.state) this.manager.updateWidget(result.instanceId, result.state.widget, 'Angular');
+      else this.manager.unmountWidget(result.instanceId);
+    }
+  }
+}

--- a/js/src/clients/WidgetStreamReducer.spec.ts
+++ b/js/src/clients/WidgetStreamReducer.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { WidgetStreamReducer, type WidgetStreamEvent } from './WidgetStreamReducer';
+import { readFileSync } from 'node:fs';
 
 const event = (overrides: Partial<WidgetStreamEvent>): WidgetStreamEvent => ({
   protocolVersion: '1.0', eventId: crypto.randomUUID(), streamId: 'demo',
@@ -8,6 +9,12 @@ const event = (overrides: Partial<WidgetStreamEvent>): WidgetStreamEvent => ({
 });
 
 describe('WidgetStreamReducer', () => {
+  it('consumes the repository shared lifecycle fixture', () => {
+    const fixture = JSON.parse(readFileSync('../test-fixtures/schema-first-lifecycle.json', 'utf8'));
+    const reducer = new WidgetStreamReducer();
+    expect(reducer.reduce(fixture.form).status).toBe('applied');
+    expect(fixture.events.map((x: WidgetStreamEvent) => reducer.reduce(x).status)).toEqual(['applied', 'applied', 'resync-required', 'applied', 'applied']);
+  });
   it('applies snapshots and patches in revision order', () => {
     const reducer = new WidgetStreamReducer();
     expect(reducer.reduce(event({ eventId: '1' })).status).toBe('applied');
@@ -28,5 +35,19 @@ describe('WidgetStreamReducer', () => {
     reducer.reduce(event({ eventId: '1' }));
     reducer.reduce(event({ eventId: '2', kind: 'widget.remove', baseRevision: 0, revision: 1, payload: {} }));
     expect(reducer.get('widget-1')).toBeUndefined();
+  });
+
+  it('replays retained reconnect events and recovers from an intentional gap with a snapshot', () => {
+    const reducer = new WidgetStreamReducer();
+    reducer.reduce(event({ eventId: 'snapshot', revision: 0 }));
+    expect(reducer.reduce(event({ eventId: 'replay-1', kind: 'widget.patch', baseRevision: 0, revision: 1, payload: [{ op: 'replace', path: '/value', value: 20 }] })).status).toBe('applied');
+    expect(reducer.reduce(event({ eventId: 'replay-2', kind: 'widget.patch', baseRevision: 1, revision: 2, payload: [{ op: 'replace', path: '/value', value: 30 }] })).status).toBe('applied');
+
+    const gap = reducer.reduce(event({ eventId: 'gap', kind: 'widget.patch', baseRevision: 3, revision: 4, payload: [] }));
+    expect(gap).toEqual({ status: 'resync-required', reason: 'revision-gap' });
+
+    const replacement = reducer.reduce(event({ eventId: 'replacement', kind: 'widget.snapshot', revision: 4, payload: { type: 'progressbar', value: 80, max: 100 } }));
+    expect(replacement.status).toBe('applied');
+    expect(reducer.get('widget-1')).toEqual({ revision: 4, widget: { type: 'progressbar', value: 80, max: 100 } });
   });
 });

--- a/js/src/renderers/WidgetManager.spec.ts
+++ b/js/src/renderers/WidgetManager.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { WidgetManager } from './WidgetManager';
-import { ButtonWidget } from '../models/ChatWidget';
+import { ButtonWidget, InputWidget, ProgressBarWidget } from '../models/ChatWidget';
 import type { IWidgetActionHandler } from '../handlers/WidgetEventManager';
 
 class TestHandler implements IWidgetActionHandler {
@@ -31,5 +31,44 @@ describe('WidgetManager integration', () => {
 
     expect(handler.calls.length).toBeGreaterThanOrEqual(1);
     expect(handler.calls[0].action).toBe('doAction');
+  });
+
+  it('orders lifecycle callbacks, preserves unrelated focused DOM state, and removes by instance ID', () => {
+    document.body.innerHTML = '<div data-widget-stream></div>';
+    const calls: string[] = [];
+    const manager = new WidgetManager({
+      lifecycle: {
+        mount: id => calls.push(`mount:${id}`),
+        update: (id, element, widget) => {
+          calls.push(`update:${id}`);
+          if (widget instanceof ProgressBarWidget) {
+            element.querySelector('progress')?.setAttribute('value', String(widget.value));
+            return true;
+          }
+        },
+        unmount: id => calls.push(`unmount:${id}`),
+      },
+    });
+
+    manager.updateWidget('form-field', new InputWidget('Name', 'name'));
+    manager.updateWidget('progress', new ProgressBarWidget('Upload', 'progress', 10, 100));
+    const input = document.querySelector('[data-widget-instance-id="form-field"] input') as HTMLInputElement;
+    const progress = document.querySelector('[data-widget-instance-id="progress"]') as Element;
+    input.value = 'unsent text';
+    input.focus();
+    input.setSelectionRange(3, 7);
+
+    manager.updateWidget('progress', new ProgressBarWidget('Upload', 'progress', 75, 100));
+
+    expect(document.querySelector('[data-widget-instance-id="form-field"] input')).toBe(input);
+    expect(document.querySelector('[data-widget-instance-id="progress"]')).toBe(progress);
+    expect(document.activeElement).toBe(input);
+    expect(input.value).toBe('unsent text');
+    expect([input.selectionStart, input.selectionEnd]).toEqual([3, 7]);
+    expect(progress.querySelector('progress')?.getAttribute('value')).toBe('75');
+
+    manager.unmountWidget('progress');
+    expect(document.querySelector('[data-widget-instance-id="progress"]')).toBeNull();
+    expect(calls).toEqual(['mount:form-field', 'mount:progress', 'update:progress', 'unmount:progress']);
   });
 });

--- a/test-fixtures/schema-first-lifecycle.json
+++ b/test-fixtures/schema-first-lifecycle.json
@@ -1,0 +1,10 @@
+{
+  "form": { "protocolVersion": "1.0", "eventId": "form-0", "streamId": "proof", "instanceId": "11111111-1111-1111-1111-111111111111", "revision": 0, "kind": "widget.snapshot", "payload": { "type": "form", "label": "Profile", "action": "save_profile", "title": "Profile", "fields": [{ "type": "input", "name": "name", "label": "Name", "required": true }], "actions": [{ "label": "Save", "type": "submit" }] } },
+  "events": [
+    { "protocolVersion": "1.0", "eventId": "progress-0", "streamId": "proof", "instanceId": "22222222-2222-2222-2222-222222222222", "revision": 0, "kind": "widget.snapshot", "payload": { "type": "progressbar", "label": "Upload", "action": "upload_progress", "value": 10, "max": 100 } },
+    { "protocolVersion": "1.0", "eventId": "progress-1", "streamId": "proof", "instanceId": "22222222-2222-2222-2222-222222222222", "baseRevision": 0, "revision": 1, "kind": "widget.patch", "payload": [{ "op": "replace", "path": "/value", "value": 50 }] },
+    { "protocolVersion": "1.0", "eventId": "progress-gap", "streamId": "proof", "instanceId": "22222222-2222-2222-2222-222222222222", "baseRevision": 2, "revision": 3, "kind": "widget.patch", "payload": [{ "op": "replace", "path": "/value", "value": 75 }] },
+    { "protocolVersion": "1.0", "eventId": "progress-resync", "streamId": "proof", "instanceId": "22222222-2222-2222-2222-222222222222", "revision": 3, "kind": "widget.snapshot", "payload": { "type": "progressbar", "label": "Upload", "action": "upload_progress", "value": 75, "max": 100 } },
+    { "protocolVersion": "1.0", "eventId": "progress-remove", "streamId": "proof", "instanceId": "22222222-2222-2222-2222-222222222222", "baseRevision": 3, "revision": 4, "kind": "widget.remove", "payload": {} }
+  ]
+}


### PR DESCRIPTION
## Summary

Completes the executable acceptance infrastructure for Schema First issues #107, #108, and #109 after the foundation merged in #110.

- adds focused SSE concurrency, cancellation, bounded slow-consumer overflow, heartbeat, replay, and replay-gap tests
- fixes replay overflow so dropped retained frames deterministically trigger `stream.resync-required`
- adds keyed Blazor and Angular protocol-envelope consumers with lifecycle callbacks and gap recovery
- adds one physical repository fixture consumed by .NET, Blazor, core JavaScript, and Angular
- proves strict FormWidget deserialization plus ProgressBar snapshots/patches, retained replay, intentional-gap resync, replacement snapshot, removal, lifecycle order, unaffected DOM identity, focus/selection, and unsent input preservation

## Issue evidence

- **#107:** six focused transport tests cover concurrency, cancellation cleanup, bounded overflow, heartbeat semantics, retained reconnect replay, and replay-gap resync.
- **#108:** core browser tests prove lifecycle order, keyed identity/removal, in-place update, focus/cursor/unsent state preservation, reconnect replay, and gap recovery; Angular and Blazor adapters execute the same contract.
- **#109:** `test-fixtures/schema-first-lifecycle.json` is the single fixture corpus used by all four supported consumers and drives an executable FormWidget + streamed ProgressBar scenario through patch, gap, resync snapshot, and removal.

## Verification

- full Release solution build: 0 MSBuild warnings, 0 errors (including Angular and React production builds)
- .NET: 272 passed, 0 failed
- core JavaScript: 57 passed; lint 0 errors; production build passed
- Angular library: 8 passed; production package build passed
- `dotnet format` completed and `git diff --check` passed